### PR TITLE
ENH: used pandas groupby to remove duplicate datetime indices

### DIFF
--- a/metar/Station.py
+++ b/metar/Station.py
@@ -291,7 +291,14 @@ class station(object):
         else:
             data = None
 
-        return data
+        # add a row number to each row
+        data['rownum'] = range(data.shape[0])
+
+        # corrected data are appended to the bottom of the ASOS files by NCDC
+        # QA people. So for any given date/time index, we want the *last* row
+        # that appeared in the data file.
+        grouped_data = data.groupby(level=0, by=['rownum'])
+        return grouped_data.last().drop(['rownum'], axis=1)
 
     def getASOSdata(self, startdate, enddate):
         '''

--- a/test/Stations_tests.py
+++ b/test/Stations_tests.py
@@ -140,7 +140,7 @@ def test_read_csv_wunderground():
     assert_equal(1,2)
     pass
 
-def test_getASOSdata():
+def test_getASOSdata_columns():
     sta, ts = makeStationAndTS()
     start = '2012-1-1'
     end = '2012-2-1'
@@ -149,6 +149,14 @@ def test_getASOSdata():
                      'DewPnt', 'WindSpd', 'WindDir', 'AtmPress']
     for col in data.columns:
         assert_in(col, known_columns)
+    pass
+
+def test_getASOSdata_index():
+    sta, ts = makeStationAndTS()
+    start = '2012-1-1'
+    end = '2012-9-1'
+    data = sta.getASOSdata(start, end)
+    assert_true(data.index.is_unique)
     pass
 
 def test_parse_dates():


### PR DESCRIPTION
... selecting the last row (corrected) inserted by NCDC
(duplicate rows exist where NCDC corrects readings from earlier in a file)
