### PR TITLE
Super small change.  Changed self.text_list to text_list in metar.py

### DIFF
--- a/metar/metar.py
+++ b/metar/metar.py
@@ -1402,7 +1402,7 @@ class Metar(object):
                     text_list.append("%s%s at %s" %
                           (SKY_COVER[cover],what,str(height)))
 
-        return sep.join(self.text_list)
+        return sep.join(text_list)
 
     def trend(self):
         """


### PR DESCRIPTION
L1405 should use local ```python text_list``` instead of global class variable of same name.