### PR TITLE
fixed bug that misparsed visibility as a wind group

### DIFF
--- a/metar/metar.py
+++ b/metar/metar.py
@@ -96,7 +96,7 @@ TIME_RE = re.compile(r"""^(?P<day>\d\d)
 MODIFIER_RE = re.compile(r"^(?P<mod>AUTO|FINO|NIL|TEST|CORR?|RTD|CC[A-G])\s+")
 
 WIND_RE = re.compile(r"""^(?P<dir>[\dO]{3}|[0O]|///|MMM|VRB)
-                          (?P<speed>P?[\dO]{2,3}|[0O]+|[/M]{2,3})
+                          (?P<speed>P?[\dO]{2,3}|[/M]{2,3})
                         (G(?P<gust>P?(\d{1,3}|[/M]{1,3})))?
                           (?P<units>KTS?|LT|K|T|KMH|MPS)?
                       (\s+(?P<varfrom>\d\d\d)V


### PR DESCRIPTION
Discovered by XavierCLL and implemented in the [TomP's version of python-metar](https://github.com/tomp/python-metar) repository.
See [tomp@bea7e7b?diff=split](tomp@bea7e7b?diff=split)